### PR TITLE
date_create() should return a DateTime instance

### DIFF
--- a/tests/overload_14.phpt
+++ b/tests/overload_14.phpt
@@ -25,6 +25,9 @@ timecop_freeze(timecop_orig_strtotime("2012-02-29 01:23:45"));
 $dt0 = new DateTime();
 var_dump(get_class($dt0));
 
+$dt1 = date_create();
+var_dump(get_class($dt1));
+
 $dts = array(
     // constuctor with 0 argument
     date_create(),
@@ -56,6 +59,7 @@ foreach ($dts as $dt) {
 }
 
 --EXPECT--
+string(8) "DateTime"
 string(8) "DateTime"
 string(25) "2012-02-29T01:23:45-08:00"
 string(25) "2012-02-29T01:23:45-08:00"

--- a/timecop_php5.c
+++ b/timecop_php5.c
@@ -1119,7 +1119,7 @@ PHP_FUNCTION(timecop_date_create)
 		RETURN_FALSE;
 	}
 
-	php_timecop_date_instantiate(TIMECOP_G(ce_TimecopDateTime), return_value TSRMLS_CC);
+	php_timecop_date_instantiate(TIMECOP_G(ce_DateTime), return_value TSRMLS_CC);
 
 	/* call TimecopDateTime::__construct() */
 	timecop_call_constructor(&return_value, TIMECOP_G(ce_TimecopDateTime), params, ZEND_NUM_ARGS() TSRMLS_CC);


### PR DESCRIPTION
`date_create()` should return a DateTime instance.
PHP7 is ok.

This PR fix issue for php5.x