### PR TITLE
Support strict_types=1 for overridden functions

### DIFF
--- a/tests/issue_043.phpt
+++ b/tests/issue_043.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Check for issue #43 (Overridden functions ignore declare(strict_types=1))
+--SKIPIF--
+<?php
+$required_version = "7.0";
+$required_func = array("strtotime");
+include(__DIR__."/tests-skipcheck.inc.php");
+--INI--
+date.timezone=GMT
+timecop.func_override=1
+--FILE--
+<?php
+declare(strict_types=1);
+
+try {
+	strtotime(null);
+	echo "No error thrown!";
+} catch (TypeError $e) {
+	echo $e->getMessage();
+}
+--EXPECT--
+timecop_strtotime() expects parameter 1 to be string, null given

--- a/timecop_php7.c
+++ b/timecop_php7.c
@@ -1088,6 +1088,17 @@ PHP_FUNCTION(timecop_time)
    Get UNIX timestamp for a date */
 PHP_FUNCTION(timecop_mktime)
 {
+	zend_long hou = 0, min = 0, sec = 0, mon = 0, day = 0, yea = 0;
+	ZEND_PARSE_PARAMETERS_START(0, 6)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(hou)
+		Z_PARAM_LONG(min)
+		Z_PARAM_LONG(sec)
+		Z_PARAM_LONG(mon)
+		Z_PARAM_LONG(day)
+		Z_PARAM_LONG(yea)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
 	TIMECOP_CALL_MKTIME("mktime", "date");
 }
 /* }}} */
@@ -1096,6 +1107,17 @@ PHP_FUNCTION(timecop_mktime)
    Get UNIX timestamp for a GMT date */
 PHP_FUNCTION(timecop_gmmktime)
 {
+	zend_long hou = 0, min = 0, sec = 0, mon = 0, day = 0, yea = 0;
+	ZEND_PARSE_PARAMETERS_START(0, 6)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(hou)
+		Z_PARAM_LONG(min)
+		Z_PARAM_LONG(sec)
+		Z_PARAM_LONG(mon)
+		Z_PARAM_LONG(day)
+		Z_PARAM_LONG(yea)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
 	TIMECOP_CALL_MKTIME("gmmktime", "gmdate");
 }
 /* }}} */
@@ -1104,6 +1126,14 @@ PHP_FUNCTION(timecop_gmmktime)
    Format a local date/time */
 PHP_FUNCTION(timecop_date)
 {
+	zend_string *format;
+	zend_long ts;
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_STR(format)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(ts)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
 	TIMECOP_CALL_FUNCTION("date", 1);
 }
 /* }}} */
@@ -1112,6 +1142,14 @@ PHP_FUNCTION(timecop_date)
    Format a GMT date/time */
 PHP_FUNCTION(timecop_gmdate)
 {
+	zend_string *format;
+	zend_long ts;
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_STR(format)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(ts)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
 	TIMECOP_CALL_FUNCTION("gmdate", 1);
 }
 /* }}} */
@@ -1120,6 +1158,14 @@ PHP_FUNCTION(timecop_gmdate)
    Format a local time/date as integer */
 PHP_FUNCTION(timecop_idate)
 {
+	zend_string *format;
+	zend_long ts;
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_STR(format)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(ts)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
 	TIMECOP_CALL_FUNCTION("idate", 1);
 }
 /* }}} */
@@ -1128,6 +1174,12 @@ PHP_FUNCTION(timecop_idate)
    Get date/time information */
 PHP_FUNCTION(timecop_getdate)
 {
+	zend_long ts;
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(ts)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
 	TIMECOP_CALL_FUNCTION("getdate", 0);
 }
 /* }}} */
@@ -1137,6 +1189,14 @@ PHP_FUNCTION(timecop_getdate)
  the associative_array argument is set to 1 other wise it is a regular array */
 PHP_FUNCTION(timecop_localtime)
 {
+	zend_long timestamp;
+	zend_bool associative;
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(timestamp)
+		Z_PARAM_BOOL(associative)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
 	TIMECOP_CALL_FUNCTION("localtime", 0);
 }
 /* }}} */
@@ -1145,6 +1205,14 @@ PHP_FUNCTION(timecop_localtime)
    Convert string representation of date and time to a timestamp */
 PHP_FUNCTION(timecop_strtotime)
 {
+	zend_string *times;
+	zend_long preset_ts;
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_STR(times)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(preset_ts)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
 	TIMECOP_CALL_FUNCTION("strtotime", 1);
 }
 /* }}} */
@@ -1153,6 +1221,14 @@ PHP_FUNCTION(timecop_strtotime)
    Format a local time/date according to locale settings */
 PHP_FUNCTION(timecop_strftime)
 {
+	zend_string *format;
+	zend_long timestamp;
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_STR(format)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(timestamp)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
 	TIMECOP_CALL_FUNCTION("strftime", 1);
 }
 /* }}} */
@@ -1161,6 +1237,14 @@ PHP_FUNCTION(timecop_strftime)
    Format a GMT/UCT time/date according to locale settings */
 PHP_FUNCTION(timecop_gmstrftime)
 {
+	zend_string *format;
+	zend_long timestamp = 0;
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_STR(format)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(timestamp)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
 	TIMECOP_CALL_FUNCTION("gmstrftime", 1);
 }
 /* }}} */


### PR DESCRIPTION
This fixes #43.
I'm simply copying the parameter parsing from official php source https://github.com/php/php-src/blob/e219ec144ef6682b71e135fd18654ee1bb4676b4/ext/date/php_date.c as it appears the strict_type checking occurs inside the `Z_PARAM_STR()`/`ZEND_PARSE_PARAMETERS_END_EX()` macros. I left the original php-source names, which is why they're a little inconsistent (heh).

As this is effectively parsing the parameters an additional time, it comes with a very slight performance hit, but I figure that's totally acceptable for a testing library if it means more correctness.