### PR TITLE
 Fix return value from DateTimeImmutable::createFromFormat()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 sudo: false
 language: php
+dist: xenial
+
+matrix:
+  include:
+    - dist: trusty
+      php: 5.4
+    - dist: trusty
+      php: 5.5
+  allow_failuers:
+    - php: master
 
 branches:
   except:
@@ -7,13 +17,13 @@ branches:
     - /^circleci-.*$/
     - /^wercker-.*$/
 
+
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - master
 
 before_script:

--- a/tests/immutable_override_008.phpt
+++ b/tests/immutable_override_008.phpt
@@ -35,6 +35,11 @@ var_dump($dt0->format("Y-m-d H:i:s.uP"));
 foreach ($tests_args as $args) {
     timecop_freeze($dt0);
     $dt1 = call_user_func_array(array("DateTimeImmutable","createFromFormat"), $args);
+    if (!$dt1 instanceof DateTimeImmutable) {
+        // TODO: output an appropriate message
+        echo get_class($dt1), "\n";
+    }
+
     var_dump($dt1->format("Y-m-d H:i:s.uP"));
     while (true) {
         /* test for equality between timecop_date_create_from_format() and date_create_from_format() */

--- a/timecop_php5.c
+++ b/timecop_php5.c
@@ -1520,6 +1520,12 @@ static void _timecop_date_create_from_format(INTERNAL_FUNCTION_PARAMETERS, int i
 
 	if (memchr(orig_format_str, '!', orig_format_len) ||
 		memchr(orig_format_str, '|', orig_format_len)) {
+
+		if (immutable) {
+			call_php_function_with_3_params(ORIG_FUNC_NAME("date_create_immutable_from_format"), &new_dt, &orig_format, &orig_time, orig_timezone);
+			RETURN_ZVAL(new_dt, 1, 1);
+		}
+
 		RETURN_ZVAL(dt, 1, 1);
 	}
 

--- a/timecop_php7.c
+++ b/timecop_php7.c
@@ -1417,7 +1417,7 @@ static void _timecop_date_create_from_format(INTERNAL_FUNCTION_PARAMETERS, int i
 {
 	zval *orig_timezone = NULL;
 	zval orig_format, orig_time, fixed_format, fixed_time, new_format, new_time;
-	zval dt, now_timestamp, tmp;
+	zval dt, dti, now_timestamp, tmp;
 	char *orig_format_str, *orig_time_str;
 	size_t  orig_format_len, orig_time_len;
 	tc_timeval now;
@@ -1440,6 +1440,12 @@ static void _timecop_date_create_from_format(INTERNAL_FUNCTION_PARAMETERS, int i
 		memchr(orig_format_str, '|', orig_format_len)) {
 		zval_ptr_dtor(&orig_format);
 		zval_ptr_dtor(&orig_time);
+
+		if (immutable) {
+			call_php_method_with_1_params(NULL, TIMECOP_G(ce_DateTimeImmutable), "createfrommutable", &dti, &dt);
+			RETURN_ZVAL(&dti, 1, 1);
+		}
+
 		RETURN_ZVAL(&dt, 1, 1);
 	}
 


### PR DESCRIPTION
When the format string contains `!` or `!`, the `DateTime` (mutable) class is returned.

refs #30 